### PR TITLE
feat(nestjs): added page number option

### DIFF
--- a/src/artists/artists.controller.ts
+++ b/src/artists/artists.controller.ts
@@ -1,13 +1,16 @@
-import { Controller, Get, Param } from '@nestjs/common'
+import { Controller, Get, Param } from '@nestjs/common';
 
-import { ArtistsService } from './artists.service'
+import { ArtistsService } from './artists.service';
 
 @Controller('artist')
 export class ArtistsController {
   constructor(private artService: ArtistsService) {}
 
-  @Get(':name')
-  async getArtistConnections(@Param('name') name: string) {
-    return await this.artService.getArtistConnections(name);
+  @Get([':name', ':name/:page'])
+  async getArtistConnections(
+    @Param('name') name: string,
+    @Param('page') pageNum = '1',
+  ) {
+    return await this.artService.getArtistConnections(name, pageNum);
   }
 }

--- a/src/artists/artists.service.ts
+++ b/src/artists/artists.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from '@nestjs/common';
 
-import { WhoSampledService } from '../common/whosampled.service'
+import { WhoSampledService } from '../common/whosampled.service';
 
 @Injectable()
 export class ArtistsService {
   constructor(private wsService: WhoSampledService) {}
 
-  async getArtistConnections(name: string) {
-    return await this.wsService.getArtistConnections(name);
+  async getArtistConnections(name: string, pageNum = '1') {
+    return await this.wsService.getArtistConnections(name, pageNum);
   }
 }

--- a/src/common/nodes.service.ts
+++ b/src/common/nodes.service.ts
@@ -6,7 +6,7 @@ export class Nodes {
         title: '.connectionTitle a',
         image: 'img@src',
       },
-    ]
+    ];
   }
 
   static detailedEntry() {
@@ -16,7 +16,7 @@ export class Nodes {
       },
       dest: {
         name: '#sampleWrap_dest  .trackName',
-        artist: '#sampleWrap_dest .sampleTrackArtists',
+        artist: '#sampleWrap_dest .sampleTrackArtists | trim',
         release: '#sampleWrap_dest .release-name a',
         year: '#sampleWrap_dest .trackLabel a',
         image: '#sampleWrap_dest .sampleTrackImage img@src',
@@ -26,14 +26,14 @@ export class Nodes {
       },
       source: {
         name: '#sampleWrap_source  .trackName',
-        artist: '#sampleWrap_source .sampleTrackArtists',
+        artist: '#sampleWrap_source .sampleTrackArtists | trim',
         release: '#sampleWrap_source .release-name a',
         year: '#sampleWrap_source .trackLabel a',
         label: '#sampleWrap_source .trackLabel span',
         image: '#sampleWrap_source .sampleTrackImage img@src',
         appearsAt: '.source-timing',
         youtubeId: '.embed-source .youtube-placeholder@data-id',
-      }
+      },
     };
   }
 }

--- a/src/common/whosampled.service.ts
+++ b/src/common/whosampled.service.ts
@@ -30,7 +30,13 @@ export class WhoSampledService {
     scope: any,
   ): Promise<[]> {
     if (!url || !selector || !scope) throw new Error('Missing parameters.');
-    const x = xray();
+    const x = xray({
+      filters: {
+        trim: function(value) {
+          return typeof value === 'string' ? value.trim() : value;
+        },
+      },
+    });
     x.driver(driver);
     return await x(url, selector, scope);
   }


### PR DESCRIPTION
added a feature for specifying the page number you want from the whosampled search. 

usage, just add the page number you want to end of the route: 
`http://localhost:3000/artist/2pac/2`

---
FYI - this builds off of the header User-Agent fix in https://github.com/thulioph/whosampled-scraper/pull/12 